### PR TITLE
Fix broken link for chatio

### DIFF
--- a/chatino/bozden/v1.0.0/MODEL_CARD.md
+++ b/chatino/bozden/v1.0.0/MODEL_CARD.md
@@ -24,7 +24,7 @@ Jump to section:
 
 ## Intended use
 
-Speech-to-Text for [Western Highland Chatino](https://en.wikipedia.org/wiki/https://en.wikipedia.org/wiki/Highland_Chatino) on 16kHz, mono-channel audio.
+Speech-to-Text for [Western Highland Chatino](https://en.wikipedia.org/wiki/Highland_Chatino) on 16kHz, mono-channel audio.
 
 ## Performance Factors
 


### PR DESCRIPTION
Leads to https://en.wikipedia.org/wiki/Https://en.wikipedia.org/wiki/Highland_Chatino otherwise.